### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,21 @@ jobs:
           - '2.4'
           - '2.3'
 
+    services:
+      redis:
+        image: redis
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
+
+    env:
+      REDIS_PORT: 6379
+
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - head
+          - '3.1'
+          - '3.0'
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+          - '2.3'
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby ${{ matrix.ruby-version }}
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # 'bundle install' and cache
+    - name: Run tests
+      run: bundle exec rake
+

--- a/spec/redis_objects_conn_spec.rb
+++ b/spec/redis_objects_conn_spec.rb
@@ -19,7 +19,7 @@ describe 'Connection tests' do
         return 1
       end
 
-      redis_handle = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 31)
+      redis_handle = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 15)
       value :redis_value, :redis => redis_handle, :key => 'rval'
       value :default_redis_value, :key => 'rval'
     end
@@ -50,7 +50,7 @@ describe 'Connection tests' do
         return 1
       end
 
-      redis_handle = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 31)
+      redis_handle = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 15)
       value :redis_value, :key => 'rval'
     end
 
@@ -72,7 +72,7 @@ describe 'Connection tests' do
         return 1
       end
 
-      redis_handle = ConnectionPool.new { Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 31) }
+      redis_handle = ConnectionPool.new { Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => 15) }
       value :redis_value, :redis => redis_handle, :key => 'rval'
       value :default_redis_value, :key => 'rval'
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ end
 Redis.exists_returns_integer =  true
 
 # Avoid phantom remote test failures
-RUNNING_LOCALLY = !ENV['TRAVIS']
+RUNNING_LOCALLY = !(ENV['CI'] || ENV['TRAVIS'])
 
 # Code coverage reports
 require 'simplecov'


### PR DESCRIPTION
Travis CI.org is now inactive.  This PR migrates CI to GitHub Actions